### PR TITLE
✨ Add site title in menu navigation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,22 +3,19 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    bigdecimal (3.1.8)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.17.0-x64-mingw-ucrt)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x64-unknown)
     forwardable-extended (2.6.0)
-    google-protobuf (4.28.0-x64-mingw-ucrt)
-      bigdecimal
-      rake (>= 13)
     http_parser.rb (0.8.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.3)
+    jekyll (4.3.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -39,8 +36,8 @@ GEM
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-paginate (1.1.0)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
+    jekyll-sass-converter (2.2.0)
+      sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
@@ -58,16 +55,15 @@ GEM
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (6.0.1)
-    rake (13.2.1)
+    public_suffix (5.1.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.3.7)
-    rouge (4.3.0)
+    rouge (3.30.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.78.0-x64-mingw-ucrt)
-      google-protobuf (~> 4.27)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     tzinfo (2.0.6)
@@ -75,11 +71,11 @@ GEM
     tzinfo-data (1.2024.2)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
-    wdm (0.2.0)
     webrick (1.8.1)
 
 PLATFORMS
-  x64-mingw-ucrt
+  arm64-darwin-23
+  x64-unknown
 
 DEPENDENCIES
   jekyll-archives
@@ -89,7 +85,6 @@ DEPENDENCIES
   jekyll-sitemap
   tzinfo
   tzinfo-data
-  wdm (>= 0.1.0)
 
 BUNDLED WITH
-   2.5.18
+   2.4.22

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,6 +52,8 @@
             {% else %}
             <span class="d-none d-md-inline-block">{{ site.title }}</span>
             {% endif %}
+
+            <span class="font-weight-bold serif-font">Hugging Face KREW Blog</span>
           </a>
 
           <button


### PR DESCRIPTION
**Before**
<img width="408" alt="image" src="https://github.com/user-attachments/assets/07d14346-73b1-4952-bd2d-f9619808473a">

**After**
<img width="450" alt="image" src="https://github.com/user-attachments/assets/6cb5f60c-4233-4e27-973a-e8424616e4f9">

메뉴 네비게이션에 블로그 이름을 추가하였습니다. 