### PR TITLE
✨ navi bar, page title image, author 모바일 최적화

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,6 @@
 <div class="footer">
-    <h4 style="text-align: center;"><span> 〰️〰️ 열린 프로젝트 〰️〰️ </span></h4>
+    <h4 style="text-align: center;"><span>  열린 프로젝트  </span></h4>
 
-    <h5 style="text-align: center;"><span> 모집 중 </span></h4>
         <div class="footer-card-container">
             <a href="https://www.contribution.ac/">
                 <img src="{{site.baseurl}}/assets/images/manage/2025-OSSCA.jpg" class="footer-card" alt="이미지" />

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -6,9 +6,8 @@
   </div>
   {%endcomment%}
   <div class="sidebar-section">
-    <h4 style="text-align: center;"><span> 〰️〰️ 열린 프로젝트 〰️〰️ </span></h4>
+    <h4 style="text-align: center;"><span>  열린 프로젝트  </span></h4>
 
-    <h5 style="text-align: center;"><span> 모집 중 </span></h4>
       <a href="https://www.contribution.ac/">
         <img src="{{site.baseurl}}/assets/images/manage/2025-OSSCA.jpg" alt="이미지" />
       </a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ post_class: post-template
 <!-- Begin Article
 ================================================== -->
 
-	<div class="row" style="margin-top: 2rem;">
+	<div class="row" style="margin-top: 1rem;">
 		
 
 		<!-- Post -->        

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -79,11 +79,11 @@ post_class: post-template
 
         <!-- Author Box -->
         {% if page.author %}				
-        <div class="row post-top-meta align-items-center">
-            <div class="col-md-2 text-center text-md-left">
+        <div class="row post-top-meta ">
+            <div class="col-md-2 text-left text-md-left">
                 <img class="author-thumb" src="{{site.baseurl}}/{{author.avatar}}" alt="{{ author.display_name }}">
             </div>
-            <div class="col-md-10 text-center text-md-left">
+            <div class="col-md-10 text-left text-md-left">
                 <a target="_blank" class="link-dark" href="{{ author.web }}">{{ author.display_name }}</a><a target="_blank" href="{{ author.twitter }}" class="btn follow">Follow</a>
                 <span class="author-description">{{ author.description }}</span>						
             </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -78,7 +78,7 @@ post_class: post-template
 
 
         <!-- Author Box -->
-        {% if page.author %}				
+        {% if page.author %}
         <div class="row post-top-meta ">
             <div class="col-md-2 text-left text-md-left">
                 <img class="author-thumb" src="{{site.baseurl}}/{{author.avatar}}" alt="{{ author.display_name }}">
@@ -87,7 +87,7 @@ post_class: post-template
                 <a target="_blank" class="link-dark" href="{{ author.web }}">{{ author.display_name }}</a><a target="_blank" href="{{ author.twitter }}" class="btn follow">Follow</a>
                 <span class="author-description">{{ author.description }}</span>						
             </div>
-        </div>				
+        </div>
         {% endif %}
 
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,6 @@ post_class: post-template
 <!-- Begin Article
 ================================================== -->
 
-
 	<div class="row" style="margin-top: 1rem;">
 		
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -78,17 +78,16 @@ post_class: post-template
 
 
         <!-- Author Box -->
-        {% if page.author %}
-        <div class="row post-top-meta">
-            <div class="col-md-2">
+        {% if page.author %}				
+        <div class="row post-top-meta align-items-center">
+            <div class="col-md-2 text-center text-md-left">
                 <img class="author-thumb" src="{{site.baseurl}}/{{author.avatar}}" alt="{{ author.display_name }}">
             </div>
-            <div class="col-md-10">
-                <a target="_blank" class="link-dark" href="{{ author.web }}">{{ author.display_name }}</a><a
-                    target="_blank" href="{{ author.twitter }}" class="btn follow">Follow</a>
-                <span class="author-description">{{ author.description }}</span>
+            <div class="col-md-10 text-center text-md-left">
+                <a target="_blank" class="link-dark" href="{{ author.web }}">{{ author.display_name }}</a><a target="_blank" href="{{ author.twitter }}" class="btn follow">Follow</a>
+                <span class="author-description">{{ author.description }}</span>						
             </div>
-        </div>
+        </div>				
         {% endif %}
 
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ post_class: post-template
 <!-- Begin Article
 ================================================== -->
 
-	<div class="row" style="margin-top: 1rem;">
+	<div class="row" style="margin-top: 2rem;">
 		
 
 		<!-- Post -->        

--- a/_sass/bootstrap/_variables.scss
+++ b/_sass/bootstrap/_variables.scss
@@ -599,7 +599,7 @@ $navbar-brand-height:               $navbar-brand-font-size * $line-height-base 
 $navbar-brand-padding-y:            ($nav-link-height - $navbar-brand-height) / 2 !default;
 
 $navbar-toggler-padding-y:          .25rem !default;
-$navbar-toggler-padding-x:          .75rem !default;
+$navbar-toggler-padding-x:          .25rem !default;
 $navbar-toggler-font-size:          $font-size-lg !default;
 $navbar-toggler-border-radius:      $btn-border-radius !default;
 

--- a/assets/css/theme.scss
+++ b/assets/css/theme.scss
@@ -29,6 +29,11 @@ body {
 }
 .serif-font {
     font-family: "PT Sans", sans-serif;
+    font-size: clamp(1rem, 2.5vw, 1.5rem);
+
+    @media (max-width: 480px) {
+        font-size: clamp(0.7rem, 4vw, 1rem);
+    }
 }
 @media (max-width: 1366px) {
     .container-xl, .container-lg, .container-md, .container-sm, .container {

--- a/assets/css/theme.scss
+++ b/assets/css/theme.scss
@@ -343,6 +343,7 @@ blockquote {
 }
 .featured-image {
     display: block;
+    margin-top: 2rem;
     margin-bottom: 2rem;
 }
 


### PR DESCRIPTION
#43 
navi bar만 수정하는 이슈였는데, 모바일 최적화를 위해서 page title image, author의 정렬 수정도 포함했습니다!

### 1. navi bar 모바일 크기 조절
전)
![image](https://github.com/user-attachments/assets/ac9d87c1-69e4-45b8-a108-cba0d5566e67)

후)
![image](https://github.com/user-attachments/assets/86917af3-51e8-4194-a807-b8617c0c4f64)
아주 작게 축소되면 토글이 밑으로 내려가긴하지만 일단 폰에서 봤을때는 괜찮은 정도까지 조절했습니다.

### 2. Content heading 잘림 수정

전에는 패딩이 부족해서, 사진이 조금 잘리더라구요!

- ![스크린샷 2025-06-29 오후 12 20 00](https://github.com/user-attachments/assets/1f5234ae-f8ba-44ba-89de-235b91297ebb)
- ![스크린샷 2025-06-29 오후 12 59 07](https://github.com/user-attachments/assets/a22a53ca-ff6a-4524-9eb1-1dd5bdb98228)

사진이 안 잘리게 바꾸었습니다!
- ![스크린샷 2025-06-29 오후 12 19 53](https://github.com/user-attachments/assets/83163836-455b-4c3d-93a4-73f1c32a7b4a)
- ![스크린샷 2025-06-29 오후 12 59 11](https://github.com/user-attachments/assets/ea2f09d7-6936-437a-b279-0b085eb9caba)


### 3. 모바일에서 Author 정보 정렬 수정

전) 
- ![스크린샷 2025-06-29 오후 12 25 14](https://github.com/user-attachments/assets/cc3de5a0-aaaa-4278-ad7a-37f1edee465c)
- ![image](https://github.com/user-attachments/assets/31c462be-3644-4017-b5b8-e6906f46750b)

후) 왼쪽 정렬했습니다
- ![image](https://github.com/user-attachments/assets/75a06d14-5148-47af-ada4-74ed0c2ac713)
- ![image](https://github.com/user-attachments/assets/f610af6d-5516-4dd1-9212-1779cf085403)

### 4. 꼬불선이랑 모집이 끝나서 <모집 중> 단어도 뺐습니다! 
전)
![image](https://github.com/user-attachments/assets/baa737db-4e68-4211-912f-c6c7f75783ff)

후) 
![image](https://github.com/user-attachments/assets/d93cdc34-f273-472e-b0f3-45302898c120)