### PR TITLE
🔧Fix profile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,7 @@ authors:
   jeong:
     name: Ahn Jeong
     display_name: jeong 
-    avatar: 'assets/images/author/jeong.png'
+    avatar: 'assets/images/author/jeong.JPG'
     email: ahnjj.dev@gmail.com 
     web: https://github.com/ahnjj/
     description: "Hello, I'm jeong!🤗"

--- a/_posts/2025-05-31-2025-PseudoCon-recap.md
+++ b/_posts/2025-05-31-2025-PseudoCon-recap.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "HuggingFace KREW in 2025 PseudoCon"
-author: Jeong
+author: jeong
 categories: [contribute]
 image: assets/images/blog/posts/2025-05-31-2025-PseudoCon-recap/수도콘.webp
 ---

--- a/_posts/2025-06-22-HuggingFace-Docs-Translation-Guide.md
+++ b/_posts/2025-06-22-HuggingFace-Docs-Translation-Guide.md
@@ -1,8 +1,7 @@
 ---
 layout: post
 title: "Hugging Face transformers 기술 문서 번역 가이드"
-author: HuggingFace First PR Team
-Editor: Jeong Ahn
+author: jeong
 categories: [contribute]
 image: assets/images/blog/posts/2025-06-22-HuggingFace-Docs-Translation-Guide/transformers.png
 ---
@@ -12,7 +11,7 @@ image: assets/images/blog/posts/2025-06-22-HuggingFace-Docs-Translation-Guide/tr
 * TOC
 {:toc}
 <!--toc-->
-🤗 HuggingFace 의 transformers 공식문서 한글화 기여 방법을 전달드립니다!
+HuggingFace First PR 팀에서 제작한 transformers 공식문서 한글화 기여 가이드입니다!🤗
 
 ## 작업 준비
 


### PR DESCRIPTION
### 수정내용
- 프로필 이미지 경로 수정
- 프로필 저자명 오타 수정
- 포스팅 원저자 (HuggingFace First PR) 소개 부분 변경 : author -> 포스팅 내부로 뺌
<img width="394" height="470" alt="image" src="https://github.com/user-attachments/assets/d7695a60-c830-4b6d-85f7-5788193d367d" />
