### PR TITLE
✍️ edit: toc 하단 서식 일괄 수정

### DIFF
--- a/_posts/2025-09-14-Implementing-MCP-Servers-in-Python.md
+++ b/_posts/2025-09-14-Implementing-MCP-Servers-in-Python.md
@@ -8,7 +8,6 @@ image: assets/images/blog/posts/2025-09-14-Implementing-MCP-Servers-in-Python/th
 * TOC
 {:toc}
 <!--toc-->
-
 _이 글은 Hugging Face 블로그의 [Implementing MCP Servers in Python: An AI Shopping Assistant with Gradio](https://huggingface.co/blog/gradio-vton-mcp)를 한국어로 번역한 글입니다._
 
 ---

--- a/_posts/2025-09-14-python-tiny-agents-study.md
+++ b/_posts/2025-09-14-python-tiny-agents-study.md
@@ -8,7 +8,7 @@ image: assets/images/blog/posts/2015-09-14-python-tiny-agents/thumbnail2.png
 * TOC
 {:toc}
 <!--toc-->
-이 글은 Hugging Face 블로그의 [Tiny Agents in Python: an MCP-powered agent in ~70 lines of code](https://huggingface.co/blog/python-tiny-agents)를 읽고 공부한 내용을 바탕으로 정리했습니다. 
+_이 글은 Hugging Face 블로그의 [Tiny Agents in Python: an MCP-powered agent in ~70 lines of code](https://huggingface.co/blog/python-tiny-agents)를 읽고 공부한 내용을 바탕으로 정리했습니다._
 
 ---
 ## 주요 개념

--- a/_posts/2025-09-29-building-hf-mcp-study.md
+++ b/_posts/2025-09-29-building-hf-mcp-study.md
@@ -8,7 +8,7 @@ image: assets/images/blog/posts/2025-09-29-building-hf-mcp/thumbnail-study.png
 * TOC
 {:toc}
 <!--toc-->
-이 글은 Hugging Face 블로그의 [Building the Hugging Face MCP Server](https://huggingface.co/blog/building-hf-mcp)를 읽고 공부한 내용을 바탕으로 정리했습니다. 
+_이 글은 Hugging Face 블로그의 [Building the Hugging Face MCP Server](https://huggingface.co/blog/building-hf-mcp)를 읽고 공부한 내용을 바탕으로 정리했습니다._
 
 ---
 

--- a/_posts/2025-10-13-structured-codeagent-ko.md
+++ b/_posts/2025-10-13-structured-codeagent-ko.md
@@ -8,7 +8,6 @@ image: assets/images/blog/posts/2025-10-13-structured-codeagent/thumbnail.png
 * TOC
 {:toc}
 <!--toc-->
-
 _이 글은 Hugging Face 블로그의 [CodeAgents + Structure: A Better Way to Execute Actions](https://huggingface.co/blog/structured-codeagent)를 한국어로 번역한 글입니다._
 
 ---

--- a/_posts/2025-10-20-2025-VLM.md
+++ b/_posts/2025-10-20-2025-VLM.md
@@ -8,7 +8,6 @@ image: assets/images/blog/posts/2025-10-20-2025-VLM/thumbnail.png
 * TOC
 {:toc}
 <!--toc-->
-
 _이 글은 Hugging Face 블로그의 [Vision Language Models (Better, Faster, Stronger)](https://huggingface.co/blog/vlms-2025)를 한국어로 번역한 글입니다._
 
 ---

--- a/_posts/2025-11-02-DABStep.md
+++ b/_posts/2025-11-02-DABStep.md
@@ -8,7 +8,6 @@ image: assets/images/thumbnail_default.png
 * TOC
 {:toc}
 <!--toc-->
-
 _이 글은 Hugging Face 블로그의 [DABStep: Data Agent Benchmark for Multi-step Reasoning](https://huggingface.co/blog/dabstep)를 한국어로 번역한 글입니다._
 ---
 

--- a/_posts/2025-11-17-agent-leaderboard.md
+++ b/_posts/2025-11-17-agent-leaderboard.md
@@ -9,8 +9,7 @@ image: assets/images/blog/posts/2025-11-17-agent-leaderboard/thumbnail.png
 * TOC
 {:toc}
 <!--toc-->
-_이 글은 Hugging Face 블로그의 [Agent 
-Leaderboard: Evaluating AI Agents in Multi-Domain Scenarios](https://huggingface.co/blog/pratikbhavsar/agent-leaderboard)를 한국어로 번역한 글입니다._
+_이 글은 Hugging Face 블로그의 [Agent Leaderboard: Evaluating AI Agents in Multi-Domain Scenarios](https://huggingface.co/blog/pratikbhavsar/agent-leaderboard)를 한국어로 번역한 글입니다._
 
 ---
 

--- a/_posts/2025-11-17-hf_translation_hub_mcp_design_and_tooling.md
+++ b/_posts/2025-11-17-hf_translation_hub_mcp_design_and_tooling.md
@@ -8,10 +8,6 @@ image: assets/images/blog/posts/2025-11-17-hf_translation_hub_mcp_design_and_too
 * TOC
 {:toc}
 <!--toc-->
-
-
----
-
 > Hugging Face 번역 MCP 서버 설계 전략 및 개발 도구는 다음과 같은 **프로젝트 목표와 운영 원칙**을 중심으로 결정되었습니다.
 >
 > **(1) 문서 번역 자동화 및 범용성 확보**

--- a/_posts/2025-12-01-rteb.md
+++ b/_posts/2025-12-01-rteb.md
@@ -7,6 +7,13 @@ image: assets/images/blog/posts/2025-12-01-rteb/thumbnail.png
 
 ---
 
+* TOC
+{:toc}
+<!--toc-->
+_이 글은 Hugging Face 블로그의 [Introducing RTEB: A New Standard for Retrieval Evaluation](https://huggingface.co/blog/rteb)를 한국어로 번역한 글입니다._
+
+---
+
 # RTEB: 검색 평가의 새로운 표준
 
 **요약 –** 여러분께 새로운 벤치마크, [RTEB(Retrieval Embedding Benchmark, 검색 임베딩 벤치마크)](https://huggingface.co/spaces/mteb/leaderboard?benchmark_name=RTEB%28beta%29)의 베타 버전을 소개합니다. RTEB는 실제 환경에 사용할 임베딩 모델의 검색 정확도를 신뢰성 있게 평가하도록 설계되었습니다. 기존 벤치마크는 진정한 일반화 능력을 측정하기 어려웠으나, RTEB는 공개 및 비공개 데이터셋을 결합한 하이브리드 전략으로 이 문제를 해결합니다. 목표는 간단합니다. 모델이 이전에 접하지 않은 데이터에서 어떻게 수행하는지 측정하기 위한, 공정하고 투명하며 응용 중심의 표준을 만드는 것입니다.


### PR DESCRIPTION
### Summary
`<!--toc-->` 하단 공백을 제거하여 미리보기 텍스트가 노출되도록 조치합니다.
<img width="1074" height="765" alt="image" src="https://github.com/user-attachments/assets/c21d371f-0c6d-4a49-ae71-01701373c01c" />
