### PR TITLE
Wait for PR preview deployment

### DIFF
--- a/.github/workflows/build_pr_preview.yml
+++ b/.github/workflows/build_pr_preview.yml
@@ -42,5 +42,5 @@ jobs:
           umbrella-dir: pr-preview
           pages-base-url: hugging-face-krew.github.io
           action: auto
-          wait-for-pages-deployment: false
+          wait-for-pages-deployment: true
           qr-code: false


### PR DESCRIPTION
## Summary
- Wait for GitHub Pages deployment before publishing PR preview status/comment

## Notes
- This should reduce the window where the preview URL is visible before the page is actually available.