### PR TITLE
Serialize GitHub Pages deployments

### DIFF
--- a/.github/workflows/build_pr_preview.yml
+++ b/.github/workflows/build_pr_preview.yml
@@ -10,7 +10,9 @@ on:
       - synchronize
       - closed
 
-concurrency: pr-preview-${{ github.ref }}
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -6,7 +6,9 @@ on:
       - main
   workflow_dispatch:
 
-concurrency: pages-${{ github.ref }}
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Put PR preview and main Pages deployments in the same concurrency group
- Keep queued deployments instead of canceling in-progress ones

## Why
Multiple workflows can push to gh-pages at nearly the same time. When wait-for-pages-deployment is enabled, intermediate GitHub Pages builds can be marked errored, causing otherwise successful preview jobs to fail.