### PR TITLE
🐛 fork PR 프리뷰 배포 오류 수정

### DIFF
--- a/.github/workflows/build_pr_preview.yml
+++ b/.github/workflows/build_pr_preview.yml
@@ -1,4 +1,4 @@
-name: PR Preview
+name: PR Preview Build
 
 on:
   pull_request:
@@ -8,39 +8,34 @@ on:
       - opened
       - reopened
       - synchronize
-      - closed
 
-concurrency: pr-preview-${{ github.ref }}
+concurrency:
+  group: pr-preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
-  deploy-preview:
+  build-preview:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Ruby
-        if: github.event.action != 'closed'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2.0"
           bundler-cache: true
 
       - name: Build Jekyll site
-        if: github.event.action != 'closed'
         run: bundle exec jekyll build --baseurl "/pr-preview/pr-${{ github.event.number }}" --destination _site
 
-      - name: Deploy PR preview
-        uses: rossjrw/pr-preview-action@v1
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
         with:
-          source-dir: _site
-          preview-branch: gh-pages
-          umbrella-dir: pr-preview
-          pages-base-url: hugging-face-krew.github.io
-          action: auto
-          wait-for-pages-deployment: true
-          qr-code: false
+          name: pr-preview-site
+          path: _site
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/cleanup_pr_preview.yml
+++ b/.github/workflows/cleanup_pr_preview.yml
@@ -1,0 +1,32 @@
+name: PR Preview Cleanup
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted base branch
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Remove PR preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          pages-base-url: hugging-face-krew.github.io
+          pr-number: ${{ github.event.pull_request.number }}
+          action: remove
+          wait-for-pages-deployment: true
+          qr-code: false

--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -1,0 +1,85 @@
+name: PR Preview Deploy
+
+on:
+  workflow_run:
+    workflows:
+      - PR Preview Build
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.pull_requests[0] != null
+    concurrency:
+      group: pr-preview-deploy-${{ github.event.workflow_run.pull_requests[0].number }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted base branch
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download preview artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: pr-preview-site
+          path: _site
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Deploy PR preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: _site
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          pages-base-url: hugging-face-krew.github.io
+          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          action: deploy
+          comment: false
+          wait-for-pages-deployment: true
+          qr-code: false
+
+      - name: Comment PR with preview URL
+        uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          PREVIEW_URL: https://hugging-face-krew.github.io/pr-preview/pr-${{ github.event.workflow_run.pull_requests[0].number }}/
+        with:
+          script: |
+            const marker = '<!-- pr-preview -->';
+            const body = `${marker}\n🚀 PR Preview: ${process.env.PREVIEW_URL}`;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner: context.repo.owner, repo: context.repo.repo, issue_number }
+            );
+            const existing = comments.find(
+              (comment) => comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body
+              });
+            }


### PR DESCRIPTION
## 변경 사항
- 모든 PR에서 read-only 권한으로 Jekyll preview를 빌드하고 artifact로 업로드
- 별도의 `workflow_run`에서 artifact를 `gh-pages`에 배포
- PR 종료 시 `pull_request_target`에서 fork 코드를 실행하지 않고 preview만 정리
- 기존과 동일한 preview URL을 PR 댓글로 제공

## 배경
PR #152는 fork PR이라 `GITHUB_TOKEN`이 read-only로 제한됐고, 기존 workflow가 `gh-pages`에 push하면서 HTTP 403으로 실패했습니다.

`pull_request_target`에서 fork 코드를 직접 빌드하면 write token이 노출될 수 있어, 빌드와 배포 권한을 분리했습니다. 같은 저장소 PR과 fork PR 모두 preview를 생성합니다.

## 검증
- `git diff --check`
- YAML parser
- `actionlint` v1.7.12