### PR TITLE
🐛 fork PR 번호 조회 오류 수정

### DIFF
--- a/.github/workflows/cleanup_pr_preview.yml
+++ b/.github/workflows/cleanup_pr_preview.yml
@@ -7,6 +7,10 @@ on:
     types:
       - closed
 
+concurrency:
+  group: gh-pages-deployment
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -6,7 +6,9 @@ on:
       - main
   workflow_dispatch:
 
-concurrency: pages-${{ github.ref }}
+concurrency:
+  group: gh-pages-deployment
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -7,6 +7,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: gh-pages-deployment
+  cancel-in-progress: false
+
 permissions:
   actions: read
   contents: write
@@ -17,9 +21,6 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
-    concurrency:
-      group: pr-preview-deploy-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - name: Resolve pull request

--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -16,13 +16,36 @@ jobs:
   deploy-preview:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.pull_requests[0] != null
+      github.event.workflow_run.event == 'pull_request'
     concurrency:
-      group: pr-preview-deploy-${{ github.event.workflow_run.pull_requests[0].number }}
+      group: pr-preview-deploy-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve pull request
+        id: pr
+        uses: actions/github-script@v8
+        env:
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        with:
+          script: |
+            const head = `${process.env.HEAD_OWNER}:${process.env.HEAD_BRANCH}`;
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              base: 'main',
+              head
+            });
+
+            if (pullRequests.length !== 1) {
+              core.setFailed(`Expected one open pull request for ${head}, found ${pullRequests.length}`);
+              return;
+            }
+
+            core.setOutput('number', String(pullRequests[0].number));
+
       - name: Checkout trusted base branch
         uses: actions/checkout@v4
         with:
@@ -44,7 +67,7 @@ jobs:
           preview-branch: gh-pages
           umbrella-dir: pr-preview
           pages-base-url: hugging-face-krew.github.io
-          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          pr-number: ${{ steps.pr.outputs.number }}
           action: deploy
           comment: false
           wait-for-pages-deployment: true
@@ -53,8 +76,8 @@ jobs:
       - name: Comment PR with preview URL
         uses: actions/github-script@v8
         env:
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
-          PREVIEW_URL: https://hugging-face-krew.github.io/pr-preview/pr-${{ github.event.workflow_run.pull_requests[0].number }}/
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PREVIEW_URL: https://hugging-face-krew.github.io/pr-preview/pr-${{ steps.pr.outputs.number }}/
         with:
           script: |
             const marker = '<!-- pr-preview -->';


### PR DESCRIPTION
## 변경 사항
- fork build run에서 비어 있는 `workflow_run.pull_requests` 의존 제거
- trusted deploy workflow가 run의 head repository/branch로 GitHub API를 조회해 PR 번호 확인
- main/preview/cleanup의 `gh-pages` 쓰기를 하나의 concurrency group으로 직렬화
- 같은 저장소 PR과 fork PR에 동일한 preview 경로 및 댓글 처리

## 원인
1. PR #152의 build와 artifact 업로드는 성공했지만, fork run의 `workflow_run.pull_requests`가 빈 배열이라 deploy job이 skipped 처리됐습니다.
2. 여러 workflow가 동시에 `gh-pages`를 갱신하면 앞선 Pages build가 취소되어 URL 댓글 단계가 실행되지 않았습니다.

## 검증
- 실제 #152 head(`sungu-che:main`) 조회 시 PR 번호 152 반환
- `actionlint` v1.7.12
- `git diff --check`
- YAML parser