### PR TITLE
🐛 PR 프리뷰 댓글 형식 복원

### DIFF
--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -62,6 +62,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Deploy PR preview
+        id: preview
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: _site
@@ -77,12 +78,22 @@ jobs:
       - name: Comment PR with preview URL
         uses: actions/github-script@v8
         env:
+          ACTION_START_TIME: ${{ steps.preview.outputs['action-start-time'] }}
+          ACTION_VERSION: ${{ steps.preview.outputs['action-version'] }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          PREVIEW_URL: https://hugging-face-krew.github.io/pr-preview/pr-${{ steps.pr.outputs.number }}/
+          PREVIEW_URL: ${{ steps.preview.outputs['preview-url'] }}
+          REPOSITORY: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
         with:
           script: |
             const marker = '<!-- pr-preview -->';
-            const body = `${marker}\n🚀 PR Preview: ${process.env.PREVIEW_URL}`;
+            const body = [
+              marker,
+              `[PR Preview Action](https://github.com/rossjrw/pr-preview-action) ${process.env.ACTION_VERSION}`,
+              ':---:',
+              `| <p></p> :rocket: View preview at <br> ${process.env.PREVIEW_URL} <br><br>`,
+              `| <h6>Built to branch [\`gh-pages\`](${process.env.SERVER_URL}/${process.env.REPOSITORY}/tree/gh-pages) at ${process.env.ACTION_START_TIME}. <br> Preview will be ready when the [GitHub Pages deployment](${process.env.SERVER_URL}/${process.env.REPOSITORY}/deployments) is complete. <br><br> </h6>`
+            ].join('\n');
             const issue_number = Number(process.env.PR_NUMBER);
             const comments = await github.paginate(
               github.rest.issues.listComments,


### PR DESCRIPTION
## 변경 사항
- PR preview 댓글을 기존 `PR Preview Action` 카드 형식으로 복원
- action 출력값을 사용해 버전, preview URL, 배포 branch와 시간을 표시
- 기존 단순 텍스트 sticky comment는 다음 preview 배포 시 같은 댓글에서 업데이트

## 배경
권한 분리 후 `workflow_run`에서 PR 번호를 직접 해석해야 해서 기본 comment 기능 대신 custom comment를 사용했지만, 본문 포맷이 단순 텍스트로 변경됐습니다. 기존 action의 카드 Markdown을 동일하게 적용합니다.

## 검증
- `actionlint` v1.7.12
- `git diff --check`
- YAML parser