### PR TITLE
Fix: Improve post thumbnail layout with fixed aspect ratio

### DIFF
--- a/_includes/postbox.html
+++ b/_includes/postbox.html
@@ -1,9 +1,11 @@
 <!-- begin post -->
 {% assign author = site.authors[post.author] %}
 <div class="card">
-    <a href="{{ post.url | absolute_url }}">
-        {% if post.image %} <img class="rounded mb-4" src="{{ site.baseurl }}/{{ post.image }}" alt="{{ post.title }}"> {% endif %}
+    {% if post.image %}
+    <a class="post-thumbnail-link" href="{{ post.url | absolute_url }}">
+        <img class="post-thumbnail rounded" src="{{ site.baseurl }}/{{ post.image }}" alt="{{ post.title }}" width="1160" height="580">
     </a>
+    {% endif %}
     <div class="card-block">
         <h2 class="card-title h4 serif-font"><a href="{{ post.url | absolute_url }}">{{ post.title }}</a></h2>
         <p class="card-text text-muted">{{ post.excerpt | strip_html | truncatewords:15 }}</p>

--- a/assets/css/theme.scss
+++ b/assets/css/theme.scss
@@ -479,6 +479,21 @@ blockquote {
 .card {	
     border:0;
 }
+.card .post-thumbnail-link {
+    display: block;
+    width: 100%;
+    aspect-ratio: 1160 / 580;
+    margin-bottom: 1.5rem;
+    overflow: hidden;
+    border-radius: 4px;
+}
+.card .post-thumbnail {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+}
 .card .img-thumb {
 	border-top-right-radius:4px;
 	border-top-left-radius:4px;


### PR DESCRIPTION
## 요약

메인/목록 카드의 썸네일 이미지 표시 방식을 개선했습니다.

## 변경사항

1.  `_includes/postbox.html`
  - 기존 img 클래스 대신 post-thumbnail-link, post-thumbnail 클래스를 추가했습니다.
  - 이미지에 width="1160", height="580"속성을 명시했습니다.

2. `assets/css/theme.scss`
  - 카드 썸네일 영역에 aspect-ratio: 1160 / 580을 적용했습니다.
  - width: 100%, height: 100%, object-fit: cover를 적용했습니다.
  - 썸네일 링크 영역에 "overflow: hidden", "border-radius", "margin-bottom" 스타일을 추가했습니다.

## 테스트
<img width="1492" height="1007" alt="1782948080521" src="https://github.com/user-attachments/assets/16904049-b231-47d7-ad56-662adeb01772" />
