### PR TITLE
✨ HF Agent PR 루프 연결

### DIFF
--- a/.github/workflows/hf-agent-feedback.yml
+++ b/.github/workflows/hf-agent-feedback.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: 5a662e8a9ea252afa76ca2686a81970610a6eca6
+          ref: 9228de6abce71a0d29a229b2cadd19c5ee83ad63
           path: workflow
 
       - name: Authorize and snapshot feedback
@@ -66,7 +66,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@5a662e8a9ea252afa76ca2686a81970610a6eca6
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@9228de6abce71a0d29a229b2cadd19c5ee83ad63
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.authorize.outputs.pr_number }}
@@ -74,7 +74,7 @@ jobs:
       expected_head_sha: ${{ needs.authorize.outputs.head_sha }}
       file_path: ${{ needs.authorize.outputs.file_path }}
       feedback: ${{ fromJSON(needs.authorize.outputs.feedback_json) }}
-      workflow_ref: 5a662e8a9ea252afa76ca2686a81970610a6eca6
+      workflow_ref: 9228de6abce71a0d29a229b2cadd19c5ee83ad63
     secrets:
       KREW_BOT_TOKEN: ${{ secrets.KREW_BOT_TOKEN }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/hf-agent-feedback.yml
+++ b/.github/workflows/hf-agent-feedback.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: 4281fc77e83bdfd85dc8b35a3a6c125467faffda
+          ref: c4b355e96f397764ef180f049e97aa2155944829
           token: ${{ secrets.KREW_BOT_TOKEN }}
           path: workflow
 
@@ -73,7 +73,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@4281fc77e83bdfd85dc8b35a3a6c125467faffda
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@c4b355e96f397764ef180f049e97aa2155944829
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.authorize.outputs.pr_number }}
@@ -81,7 +81,7 @@ jobs:
       expected_head_sha: ${{ needs.authorize.outputs.head_sha }}
       file_path: ${{ needs.authorize.outputs.file_path }}
       feedback: ${{ fromJSON(needs.authorize.outputs.feedback_json) }}
-      workflow_ref: 4281fc77e83bdfd85dc8b35a3a6c125467faffda
+      workflow_ref: c4b355e96f397764ef180f049e97aa2155944829
       review_comment_id: ${{ needs.authorize.outputs.review_comment_id }}
     secrets:
       KREW_BOT_TOKEN: ${{ secrets.KREW_BOT_TOKEN }}

--- a/.github/workflows/hf-agent-feedback.yml
+++ b/.github/workflows/hf-agent-feedback.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: c4b355e96f397764ef180f049e97aa2155944829
+          ref: 22ffbec9efb5a9eb7dc20f73bf789ae66427c147
           token: ${{ secrets.KREW_BOT_TOKEN }}
           path: workflow
 
@@ -73,7 +73,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@c4b355e96f397764ef180f049e97aa2155944829
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@22ffbec9efb5a9eb7dc20f73bf789ae66427c147
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.authorize.outputs.pr_number }}
@@ -81,7 +81,7 @@ jobs:
       expected_head_sha: ${{ needs.authorize.outputs.head_sha }}
       file_path: ${{ needs.authorize.outputs.file_path }}
       feedback: ${{ fromJSON(needs.authorize.outputs.feedback_json) }}
-      workflow_ref: c4b355e96f397764ef180f049e97aa2155944829
+      workflow_ref: 22ffbec9efb5a9eb7dc20f73bf789ae66427c147
       review_comment_id: ${{ needs.authorize.outputs.review_comment_id }}
     secrets:
       KREW_BOT_TOKEN: ${{ secrets.KREW_BOT_TOKEN }}

--- a/.github/workflows/hf-agent-feedback.yml
+++ b/.github/workflows/hf-agent-feedback.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: 54bf9d30f7946796fd4c4d88d5651c9f105a3c4f
+          ref: 0d20d3c63617feca6ba293419657636ed34f3bc1
           path: workflow
 
       - name: Authorize and snapshot feedback
@@ -72,7 +72,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@54bf9d30f7946796fd4c4d88d5651c9f105a3c4f
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@0d20d3c63617feca6ba293419657636ed34f3bc1
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.authorize.outputs.pr_number }}
@@ -80,7 +80,7 @@ jobs:
       expected_head_sha: ${{ needs.authorize.outputs.head_sha }}
       file_path: ${{ needs.authorize.outputs.file_path }}
       feedback: ${{ fromJSON(needs.authorize.outputs.feedback_json) }}
-      workflow_ref: 54bf9d30f7946796fd4c4d88d5651c9f105a3c4f
+      workflow_ref: 0d20d3c63617feca6ba293419657636ed34f3bc1
       review_comment_id: ${{ needs.authorize.outputs.review_comment_id }}
     secrets:
       KREW_BOT_TOKEN: ${{ secrets.KREW_BOT_TOKEN }}

--- a/.github/workflows/hf-agent-feedback.yml
+++ b/.github/workflows/hf-agent-feedback.yml
@@ -26,12 +26,13 @@ jobs:
       file_path: ${{ steps.route.outputs.file_path }}
       head_sha: ${{ steps.route.outputs.head_sha }}
       pr_number: ${{ steps.route.outputs.pr_number }}
+      review_comment_id: ${{ steps.route.outputs.review_comment_id }}
     steps:
       - name: Checkout workflow tools
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: 9228de6abce71a0d29a229b2cadd19c5ee83ad63
+          ref: 54bf9d30f7946796fd4c4d88d5651c9f105a3c4f
           path: workflow
 
       - name: Authorize and snapshot feedback
@@ -59,6 +60,11 @@ jobs:
           echo "file_path=$(jq -r .file_path "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
           echo "head_sha=$(jq -r .head_sha "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          if [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ]; then
+            echo "review_comment_id=$(jq -r .comment_id "${{ runner.temp }}/route.json")" >> "$GITHUB_OUTPUT"
+          else
+            echo "review_comment_id=" >> "$GITHUB_OUTPUT"
+          fi
 
   mutate:
     needs: authorize
@@ -66,7 +72,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@9228de6abce71a0d29a229b2cadd19c5ee83ad63
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@54bf9d30f7946796fd4c4d88d5651c9f105a3c4f
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.authorize.outputs.pr_number }}
@@ -74,7 +80,8 @@ jobs:
       expected_head_sha: ${{ needs.authorize.outputs.head_sha }}
       file_path: ${{ needs.authorize.outputs.file_path }}
       feedback: ${{ fromJSON(needs.authorize.outputs.feedback_json) }}
-      workflow_ref: 9228de6abce71a0d29a229b2cadd19c5ee83ad63
+      workflow_ref: 54bf9d30f7946796fd4c4d88d5651c9f105a3c4f
+      review_comment_id: ${{ needs.authorize.outputs.review_comment_id }}
     secrets:
       KREW_BOT_TOKEN: ${{ secrets.KREW_BOT_TOKEN }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/hf-agent-feedback.yml
+++ b/.github/workflows/hf-agent-feedback.yml
@@ -29,10 +29,10 @@ jobs:
       review_comment_id: ${{ steps.route.outputs.review_comment_id }}
     steps:
       - name: Checkout workflow tools
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: f4966d52459246f05ef5644a57a4ce1b50dba0ee
+          ref: 4281fc77e83bdfd85dc8b35a3a6c125467faffda
           token: ${{ secrets.KREW_BOT_TOKEN }}
           path: workflow
 
@@ -73,7 +73,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@f4966d52459246f05ef5644a57a4ce1b50dba0ee
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@4281fc77e83bdfd85dc8b35a3a6c125467faffda
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.authorize.outputs.pr_number }}
@@ -81,7 +81,7 @@ jobs:
       expected_head_sha: ${{ needs.authorize.outputs.head_sha }}
       file_path: ${{ needs.authorize.outputs.file_path }}
       feedback: ${{ fromJSON(needs.authorize.outputs.feedback_json) }}
-      workflow_ref: f4966d52459246f05ef5644a57a4ce1b50dba0ee
+      workflow_ref: 4281fc77e83bdfd85dc8b35a3a6c125467faffda
       review_comment_id: ${{ needs.authorize.outputs.review_comment_id }}
     secrets:
       KREW_BOT_TOKEN: ${{ secrets.KREW_BOT_TOKEN }}

--- a/.github/workflows/hf-agent-feedback.yml
+++ b/.github/workflows/hf-agent-feedback.yml
@@ -1,0 +1,80 @@
+name: HF Agent PR Feedback
+
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  authorize:
+    name: HF Agent / Authorize Feedback
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.route.outputs.branch }}
+      eligible: ${{ steps.route.outputs.eligible }}
+      feedback_json: ${{ steps.route.outputs.feedback_json }}
+      file_path: ${{ steps.route.outputs.file_path }}
+      head_sha: ${{ steps.route.outputs.head_sha }}
+      pr_number: ${{ steps.route.outputs.pr_number }}
+    steps:
+      - name: Checkout workflow tools
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: Hugging-Face-KREW/hf-workflow
+          ref: 5a662e8a9ea252afa76ca2686a81970610a6eca6
+          path: workflow
+
+      - name: Authorize and snapshot feedback
+        id: route
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PYTHONPATH: workflow/scripts
+        run: |
+          if ! python -m hf_agent.route_pr_feedback \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --event-path "$GITHUB_EVENT_PATH" \
+            --repository "${{ github.repository }}" \
+            --result-json "${{ runner.temp }}/route.json"; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pr_number=$(jq -r .pr_number "${{ runner.temp }}/route.json")
+          python -m hf_agent.snapshot_pr \
+            --repository "${{ github.repository }}" \
+            --pr-number "$pr_number" \
+            --result-json "${{ runner.temp }}/snapshot.json"
+          echo "branch=$(jq -r .branch "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
+          echo "eligible=$(jq -r .managed "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
+          echo "feedback_json=$(jq -c .body "${{ runner.temp }}/route.json")" >> "$GITHUB_OUTPUT"
+          echo "file_path=$(jq -r .file_path "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(jq -r .head_sha "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+  mutate:
+    needs: authorize
+    if: ${{ needs.authorize.outputs.eligible == 'true' }}
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@5a662e8a9ea252afa76ca2686a81970610a6eca6
+    with:
+      target_repo: ${{ github.repository }}
+      pr_number: ${{ needs.authorize.outputs.pr_number }}
+      branch: ${{ needs.authorize.outputs.branch }}
+      expected_head_sha: ${{ needs.authorize.outputs.head_sha }}
+      file_path: ${{ needs.authorize.outputs.file_path }}
+      feedback: ${{ fromJSON(needs.authorize.outputs.feedback_json) }}
+      workflow_ref: 5a662e8a9ea252afa76ca2686a81970610a6eca6
+    secrets:
+      KREW_BOT_TOKEN: ${{ secrets.KREW_BOT_TOKEN }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/hf-agent-feedback.yml
+++ b/.github/workflows/hf-agent-feedback.yml
@@ -32,7 +32,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: 0d20d3c63617feca6ba293419657636ed34f3bc1
+          ref: f4966d52459246f05ef5644a57a4ce1b50dba0ee
+          token: ${{ secrets.KREW_BOT_TOKEN }}
           path: workflow
 
       - name: Authorize and snapshot feedback
@@ -72,7 +73,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@0d20d3c63617feca6ba293419657636ed34f3bc1
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@f4966d52459246f05ef5644a57a4ce1b50dba0ee
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.authorize.outputs.pr_number }}
@@ -80,7 +81,7 @@ jobs:
       expected_head_sha: ${{ needs.authorize.outputs.head_sha }}
       file_path: ${{ needs.authorize.outputs.file_path }}
       feedback: ${{ fromJSON(needs.authorize.outputs.feedback_json) }}
-      workflow_ref: 0d20d3c63617feca6ba293419657636ed34f3bc1
+      workflow_ref: f4966d52459246f05ef5644a57a4ce1b50dba0ee
       review_comment_id: ${{ needs.authorize.outputs.review_comment_id }}
     secrets:
       KREW_BOT_TOKEN: ${{ secrets.KREW_BOT_TOKEN }}

--- a/.github/workflows/hf-agent-review.yml
+++ b/.github/workflows/hf-agent-review.yml
@@ -1,0 +1,69 @@
+name: HF Agent PR Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  context:
+    name: HF Agent / Capture Context
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    outputs:
+      feedback_revision: ${{ steps.snapshot.outputs.feedback_revision }}
+      file_path: ${{ steps.snapshot.outputs.file_path }}
+      head_sha: ${{ steps.snapshot.outputs.head_sha }}
+      managed: ${{ steps.snapshot.outputs.managed }}
+      pr_number: ${{ steps.snapshot.outputs.pr_number }}
+    steps:
+      - name: Checkout workflow tools
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: Hugging-Face-KREW/hf-workflow
+          ref: 5a662e8a9ea252afa76ca2686a81970610a6eca6
+          path: workflow
+
+      - name: Capture trusted PR snapshot
+        id: snapshot
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          PYTHONPATH: workflow/scripts
+        run: |
+          python -m hf_agent.snapshot_pr \
+            --repository "${{ github.repository }}" \
+            --pr-number "$PR_NUMBER" \
+            --result-json "${{ runner.temp }}/snapshot.json"
+          echo "feedback_revision=$(jq -r .feedback_revision "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
+          echo "file_path=$(jq -r .file_path "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(jq -r .head_sha "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
+          echo "managed=$(jq -r .managed "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$(jq -r .pr_number "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
+
+  review:
+    needs: context
+    if: ${{ needs.context.outputs.managed == 'true' }}
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      statuses: write
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@5a662e8a9ea252afa76ca2686a81970610a6eca6
+    with:
+      target_repo: ${{ github.repository }}
+      pr_number: ${{ needs.context.outputs.pr_number }}
+      head_sha: ${{ needs.context.outputs.head_sha }}
+      file_path: ${{ needs.context.outputs.file_path }}
+      workflow_ref: 5a662e8a9ea252afa76ca2686a81970610a6eca6
+      feedback_revision: ${{ needs.context.outputs.feedback_revision }}

--- a/.github/workflows/hf-agent-review.yml
+++ b/.github/workflows/hf-agent-review.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: 5a662e8a9ea252afa76ca2686a81970610a6eca6
+          ref: 9228de6abce71a0d29a229b2cadd19c5ee83ad63
           path: workflow
 
       - name: Capture trusted PR snapshot
@@ -59,11 +59,11 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@5a662e8a9ea252afa76ca2686a81970610a6eca6
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@9228de6abce71a0d29a229b2cadd19c5ee83ad63
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.context.outputs.pr_number }}
       head_sha: ${{ needs.context.outputs.head_sha }}
       file_path: ${{ needs.context.outputs.file_path }}
-      workflow_ref: 5a662e8a9ea252afa76ca2686a81970610a6eca6
+      workflow_ref: 9228de6abce71a0d29a229b2cadd19c5ee83ad63
       feedback_revision: ${{ needs.context.outputs.feedback_revision }}

--- a/.github/workflows/hf-agent-review.yml
+++ b/.github/workflows/hf-agent-review.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: 4281fc77e83bdfd85dc8b35a3a6c125467faffda
+          ref: c4b355e96f397764ef180f049e97aa2155944829
           token: ${{ secrets.KREW_BOT_TOKEN }}
           path: workflow
 
@@ -62,14 +62,14 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@4281fc77e83bdfd85dc8b35a3a6c125467faffda
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@c4b355e96f397764ef180f049e97aa2155944829
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.context.outputs.pr_number }}
       head_sha: ${{ needs.context.outputs.head_sha }}
       file_path: ${{ needs.context.outputs.file_path }}
       branch: ${{ needs.context.outputs.branch }}
-      workflow_ref: 4281fc77e83bdfd85dc8b35a3a6c125467faffda
+      workflow_ref: c4b355e96f397764ef180f049e97aa2155944829
       feedback_revision: ${{ needs.context.outputs.feedback_revision }}
     secrets:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/hf-agent-review.yml
+++ b/.github/workflows/hf-agent-review.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: c4b355e96f397764ef180f049e97aa2155944829
+          ref: 22ffbec9efb5a9eb7dc20f73bf789ae66427c147
           token: ${{ secrets.KREW_BOT_TOKEN }}
           path: workflow
 
@@ -62,14 +62,14 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@c4b355e96f397764ef180f049e97aa2155944829
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@22ffbec9efb5a9eb7dc20f73bf789ae66427c147
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.context.outputs.pr_number }}
       head_sha: ${{ needs.context.outputs.head_sha }}
       file_path: ${{ needs.context.outputs.file_path }}
       branch: ${{ needs.context.outputs.branch }}
-      workflow_ref: c4b355e96f397764ef180f049e97aa2155944829
+      workflow_ref: 22ffbec9efb5a9eb7dc20f73bf789ae66427c147
       feedback_revision: ${{ needs.context.outputs.feedback_revision }}
     secrets:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/hf-agent-review.yml
+++ b/.github/workflows/hf-agent-review.yml
@@ -21,6 +21,7 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     outputs:
+      branch: ${{ steps.snapshot.outputs.branch }}
       feedback_revision: ${{ steps.snapshot.outputs.feedback_revision }}
       file_path: ${{ steps.snapshot.outputs.file_path }}
       head_sha: ${{ steps.snapshot.outputs.head_sha }}
@@ -31,7 +32,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: 9228de6abce71a0d29a229b2cadd19c5ee83ad63
+          ref: 54bf9d30f7946796fd4c4d88d5651c9f105a3c4f
           path: workflow
 
       - name: Capture trusted PR snapshot
@@ -45,6 +46,7 @@ jobs:
             --repository "${{ github.repository }}" \
             --pr-number "$PR_NUMBER" \
             --result-json "${{ runner.temp }}/snapshot.json"
+          echo "branch=$(jq -r .branch "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
           echo "feedback_revision=$(jq -r .feedback_revision "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
           echo "file_path=$(jq -r .file_path "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
           echo "head_sha=$(jq -r .head_sha "${{ runner.temp }}/snapshot.json")" >> "$GITHUB_OUTPUT"
@@ -59,11 +61,16 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@9228de6abce71a0d29a229b2cadd19c5ee83ad63
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@54bf9d30f7946796fd4c4d88d5651c9f105a3c4f
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.context.outputs.pr_number }}
       head_sha: ${{ needs.context.outputs.head_sha }}
       file_path: ${{ needs.context.outputs.file_path }}
-      workflow_ref: 9228de6abce71a0d29a229b2cadd19c5ee83ad63
+      branch: ${{ needs.context.outputs.branch }}
+      workflow_ref: 54bf9d30f7946796fd4c4d88d5651c9f105a3c4f
       feedback_revision: ${{ needs.context.outputs.feedback_revision }}
+    secrets:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      KREW_BOT_TOKEN: ${{ secrets.KREW_BOT_TOKEN }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/hf-agent-review.yml
+++ b/.github/workflows/hf-agent-review.yml
@@ -32,7 +32,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: 0d20d3c63617feca6ba293419657636ed34f3bc1
+          ref: f4966d52459246f05ef5644a57a4ce1b50dba0ee
+          token: ${{ secrets.KREW_BOT_TOKEN }}
           path: workflow
 
       - name: Capture trusted PR snapshot
@@ -61,14 +62,14 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@0d20d3c63617feca6ba293419657636ed34f3bc1
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@f4966d52459246f05ef5644a57a4ce1b50dba0ee
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.context.outputs.pr_number }}
       head_sha: ${{ needs.context.outputs.head_sha }}
       file_path: ${{ needs.context.outputs.file_path }}
       branch: ${{ needs.context.outputs.branch }}
-      workflow_ref: 0d20d3c63617feca6ba293419657636ed34f3bc1
+      workflow_ref: f4966d52459246f05ef5644a57a4ce1b50dba0ee
       feedback_revision: ${{ needs.context.outputs.feedback_revision }}
     secrets:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/hf-agent-review.yml
+++ b/.github/workflows/hf-agent-review.yml
@@ -29,10 +29,10 @@ jobs:
       pr_number: ${{ steps.snapshot.outputs.pr_number }}
     steps:
       - name: Checkout workflow tools
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: f4966d52459246f05ef5644a57a4ce1b50dba0ee
+          ref: 4281fc77e83bdfd85dc8b35a3a6c125467faffda
           token: ${{ secrets.KREW_BOT_TOKEN }}
           path: workflow
 
@@ -62,14 +62,14 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@f4966d52459246f05ef5644a57a4ce1b50dba0ee
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@4281fc77e83bdfd85dc8b35a3a6c125467faffda
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.context.outputs.pr_number }}
       head_sha: ${{ needs.context.outputs.head_sha }}
       file_path: ${{ needs.context.outputs.file_path }}
       branch: ${{ needs.context.outputs.branch }}
-      workflow_ref: f4966d52459246f05ef5644a57a4ce1b50dba0ee
+      workflow_ref: 4281fc77e83bdfd85dc8b35a3a6c125467faffda
       feedback_revision: ${{ needs.context.outputs.feedback_revision }}
     secrets:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/hf-agent-review.yml
+++ b/.github/workflows/hf-agent-review.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: 54bf9d30f7946796fd4c4d88d5651c9f105a3c4f
+          ref: 0d20d3c63617feca6ba293419657636ed34f3bc1
           path: workflow
 
       - name: Capture trusted PR snapshot
@@ -61,14 +61,14 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@54bf9d30f7946796fd4c4d88d5651c9f105a3c4f
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@0d20d3c63617feca6ba293419657636ed34f3bc1
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.context.outputs.pr_number }}
       head_sha: ${{ needs.context.outputs.head_sha }}
       file_path: ${{ needs.context.outputs.file_path }}
       branch: ${{ needs.context.outputs.branch }}
-      workflow_ref: 54bf9d30f7946796fd4c4d88d5651c9f105a3c4f
+      workflow_ref: 0d20d3c63617feca6ba293419657636ed34f3bc1
       feedback_revision: ${{ needs.context.outputs.feedback_revision }}
     secrets:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/hf-agent-review.yml
+++ b/.github/workflows/hf-agent-review.yml
@@ -2,7 +2,7 @@ name: HF Agent PR Review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [opened, reopened, ready_for_review, synchronize, labeled]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
## 변경 사항

- 대상 repo에서 PR 생성/동기화/코멘트 이벤트를 중앙 `hf-workflow` agent workflow로 전달하는 thin caller workflow를 추가했습니다.
- 중앙 workflow pin을 `c4b355e96f397764ef180f049e97aa2155944829`로 갱신했습니다.
- target repo secret `KREW_BOT_TOKEN`, `OPENAI_API_KEY`를 사용해 private central workflow checkout과 repair mutation을 수행합니다.

## 검증

- caller workflow YAML parse 통과
- caller contract tests: `3 passed`
- #164 `build-preview` 통과: https://github.com/Hugging-Face-KREW/hugging-face-krew.github.io/actions/runs/28727525198
- #154 controlled failure-to-repair E2E 통과:
  - failure/repair run: https://github.com/Hugging-Face-KREW/hugging-face-krew.github.io/actions/runs/28727045979
  - green verification run: https://github.com/Hugging-Face-KREW/hugging-face-krew.github.io/actions/runs/28727060437

## 머지 순서

1. 중앙 stacked PR #19 → #20 → #21
2. 이 PR #164

중앙 reusable workflow는 default branch에 있어야 target repo event에서 안정적으로 호출됩니다.

## Cleanup TODO

- 중앙 stacked PR #19 → #20 → #21 및 이 PR #164가 merge된 뒤, E2E 검증용 임시 workflow를 제거합니다.
  - #154: `.github/workflows/hf-agent-e2e-154.yml`
  - #161: `.github/workflows/hf-agent-e2e-161.yml`
