### PR TITLE
🔧 Use merged quality harness workflow

### DIFF
--- a/.github/workflows/hf-agent-review.yml
+++ b/.github/workflows/hf-agent-review.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: 22ffbec9efb5a9eb7dc20f73bf789ae66427c147
+          ref: 310c969249f7dd4eb796f73355ef11ff3d281dcc
           token: ${{ secrets.KREW_BOT_TOKEN }}
           path: workflow
 
@@ -59,17 +59,18 @@ jobs:
     if: ${{ needs.context.outputs.managed == 'true' }}
     permissions:
       actions: read
+      issues: write
       contents: read
       pull-requests: write
       statuses: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@22ffbec9efb5a9eb7dc20f73bf789ae66427c147
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@310c969249f7dd4eb796f73355ef11ff3d281dcc
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.context.outputs.pr_number }}
       head_sha: ${{ needs.context.outputs.head_sha }}
       file_path: ${{ needs.context.outputs.file_path }}
       branch: ${{ needs.context.outputs.branch }}
-      workflow_ref: 22ffbec9efb5a9eb7dc20f73bf789ae66427c147
+      workflow_ref: 310c969249f7dd4eb796f73355ef11ff3d281dcc
       feedback_revision: ${{ needs.context.outputs.feedback_revision }}
     secrets:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

- Pin the HF Agent caller to merged `hf-workflow` commit `310c969249f7dd4eb796f73355ef11ff3d281dcc`
- Grant `issues: write` so the reusable workflow can remove stale `hf-agent:needs-human` labels

## Validation

- Caller YAML parses successfully
- All three workflow-tool references use the same merged SHA
- `hf-workflow` PR #23: 292 tests passed and Quality Harness Tests succeeded
- Artifact reuse E2E: https://github.com/Hugging-Face-KREW/hugging-face-krew.github.io/actions/runs/30098383436