### PR TITLE
🔧 Update HF Agent workflow reference

### DIFF
--- a/.github/workflows/hf-agent-feedback.yml
+++ b/.github/workflows/hf-agent-feedback.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: d0aaac971c16e4d1e00ba815a63158a90ed15533
+          ref: 530521318e28c1c82491393e264fe608aa029634
           token: ${{ secrets.KREW_BOT_TOKEN }}
           path: workflow
 
@@ -73,7 +73,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@d0aaac971c16e4d1e00ba815a63158a90ed15533
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-mutate.yml@530521318e28c1c82491393e264fe608aa029634
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.authorize.outputs.pr_number }}
@@ -81,7 +81,7 @@ jobs:
       expected_head_sha: ${{ needs.authorize.outputs.head_sha }}
       file_path: ${{ needs.authorize.outputs.file_path }}
       feedback: ${{ fromJSON(needs.authorize.outputs.feedback_json) }}
-      workflow_ref: d0aaac971c16e4d1e00ba815a63158a90ed15533
+      workflow_ref: 530521318e28c1c82491393e264fe608aa029634
       review_comment_id: ${{ needs.authorize.outputs.review_comment_id }}
     secrets:
       KREW_BOT_TOKEN: ${{ secrets.KREW_BOT_TOKEN }}

--- a/.github/workflows/hf-agent-review.yml
+++ b/.github/workflows/hf-agent-review.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           repository: Hugging-Face-KREW/hf-workflow
-          ref: d0aaac971c16e4d1e00ba815a63158a90ed15533
+          ref: 530521318e28c1c82491393e264fe608aa029634
           token: ${{ secrets.KREW_BOT_TOKEN }}
           path: workflow
 
@@ -63,14 +63,14 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
-    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@d0aaac971c16e4d1e00ba815a63158a90ed15533
+    uses: Hugging-Face-KREW/hf-workflow/.github/workflows/reusable-pr-review.yml@530521318e28c1c82491393e264fe608aa029634
     with:
       target_repo: ${{ github.repository }}
       pr_number: ${{ needs.context.outputs.pr_number }}
       head_sha: ${{ needs.context.outputs.head_sha }}
       file_path: ${{ needs.context.outputs.file_path }}
       branch: ${{ needs.context.outputs.branch }}
-      workflow_ref: d0aaac971c16e4d1e00ba815a63158a90ed15533
+      workflow_ref: 530521318e28c1c82491393e264fe608aa029634
       feedback_revision: ${{ needs.context.outputs.feedback_revision }}
     secrets:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
## 변경

site의 production PR Agent caller가 최신 `hf-workflow` merge SHA `530521318e28c1c82491393e264fe608aa029634`를 사용하도록 갱신합니다.

- review caller checkout/ref/`workflow_ref` 동기화
- feedback caller checkout/ref/`workflow_ref` 동기화

## 포함되는 수정

- [hf-workflow #27](https://github.com/Hugging-Face-KREW/hf-workflow/pull/27): MQM judge skip artifact verifier 처리
- [hf-workflow #28](https://github.com/Hugging-Face-KREW/hf-workflow/pull/28): strict structured repair output 및 긴 Markdown 출력 한도

## 머지 후 검증

PR #132, #131, #181, #180, #178의 `HF Agent PR Review`를 workflow dispatch로 재실행합니다.